### PR TITLE
added quotes within string literal

### DIFF
--- a/lib/sinatra_generator/templates/main.rb
+++ b/lib/sinatra_generator/templates/main.rb
@@ -1,4 +1,4 @@
-<%- options[:views] ? @view = 'erb :index' : @view = 'hello world' -%>
+<%- options[:views] ? @view = 'erb :index' : @view = "'hello world'" -%>
 <%- if options[:modular] -%>
 require 'sinatra/base' 
 


### PR DESCRIPTION
As stands, default main.rb file generates with quoteless string on line 5, resulting in NameError if app is run without edits. 

Added single quotes to string literal by way of resolution. 
