### PR TITLE
Fix meta tag in layout head

### DIFF
--- a/lib/sinatra_generator/templates/layout.erb
+++ b/lib/sinatra_generator/templates/layout.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Hello World</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 


### PR DESCRIPTION
I found that when using the Sinatra Generator to create apps, that the layout template was not respecting the media queries I set in the browser. It turns out that there is an error in the meta tag with a missing double quote.

You should now see that the window is responsive with this fix.

😄 